### PR TITLE
Look for the default app name from the environment

### DIFF
--- a/stubs/ExampleTest.stub
+++ b/stubs/ExampleTest.stub
@@ -17,7 +17,7 @@ class ExampleTest extends DuskTestCase
     {
         $this->browse(function (Browser $browser) {
             $browser->visit('/')
-                    ->assertSee('Laravel');
+                    ->assertSee(env('APP_NAME', 'Laravel'));
         });
     }
 }


### PR DESCRIPTION
Most projects will have the project's name by default on the Homepage.

So we can look for the APP_NAME instead of "Laravel" on with the ExampleTest.

So it will reduce 1 step of going back to the ExampleTest and changing it.
